### PR TITLE
Replace prater by mainnet in urls and package name

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1,9 +1,9 @@
 How Rocket Pool Works. Unlike solo stakers, who are required to put 32 ETH up for deposit to create a new validator, Rocket Pool nodes only need to deposit 8/16 ETH per validator. This will be coupled with 16 ETH from the staking pool (which stakers deposited in exchange for rETH) to create a new Ethereum validator. This new validator is called a minipool.
 
-Start with Rocket Pool at [http://rocketpool-testnet.public.dappnode/](http://rocketpool-testnet.public.dappnode/)
+Start with Rocket Pool at [http://rocketpool.public.dappnode/](http://rocketpool.public.dappnode/)
 
 ℹ️ Rocket Pool supports three different Execution clients: Geth, Besu, and Nethermind.
 
 ℹ️ Rocket Pool supports five Consensus clients: Lighthouse, Lodestar, Nimbus, Prysm, and Teku.
 
-⚠️ When creating a wallet or adding a minipool, it is crucial to go to the [backup tab](http://my.dappnode/#/packages/rocketpool-testnet.public.dappnode.eth/backup) and download your backup, as it provides a necessary safety measure in case of any unforeseen circumstances that may cause data loss or corruption, and ensures that you can easily recover your information when required.
+⚠️ When creating a wallet or adding a minipool, it is crucial to go to the [backup tab](http://my.dappnode/#/packages/rocketpool.public.dappnode.eth/backup) and download your backup, as it provides a necessary safety measure in case of any unforeseen circumstances that may cause data loss or corruption, and ensures that you can easily recover your information when required.

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rocketpool-testnet.public.dappnode.eth",
+  "name": "rocketpool.public.dappnode.eth",
   "version": "0.1.0",
   "upstreamVersion": "v1.9.2",
   "upstreamRepo": "rocket-pool/smartnode-install",
@@ -9,20 +9,20 @@
   "author": "dappnode",
   "categories": ["Developer tools"],
   "links": {
-    "ui": "http://rocketpool-testnet.public.dappnode/",
+    "ui": "http://rocketpool.public.dappnode/",
     "homepage": "https://rocketpool.net/"
   },
   "globalEnvs": [
     {
-      "envs": ["EXECUTION_CLIENT_PRATER", "CONSENSUS_CLIENT_PRATER"],
-      "services": ["rocketpool-testnet.public.dappnode.eth"]
+      "envs": ["EXECUTION_CLIENT_MAINNET", "CONSENSUS_CLIENT_MAINNET"],
+      "services": ["rocketpool.public.dappnode.eth"]
     }
   ],
   "backup": [
     {
       "name": "data",
       "path": "/rocketpool/data",
-      "service": "rocketpool-testnet.public.dappnode.eth"
+      "service": "rocketpool.public.dappnode.eth"
     }
   ],
   "license": "GLP-3.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,18 @@
 version: "3.4"
 services:
-  rocketpool-testnet.public.dappnode.eth:
-    image: "rocketpool-testnet.public.dappnode.eth:0.1.0"
+  rocketpool.public.dappnode.eth:
+    image: "rocketpool.public.dappnode.eth:0.1.0"
     build:
       context: ./build
       args:
         UPSTREAM_VERSION: v1.9.2
-        NETWORK: prater
+        NETWORK: mainnet
     volumes:
-      - "rocketpool-testnet:/rocketpool"
+      - "rocketpool:/rocketpool"
     environment:
-      - NETWORK=prater
+      - NETWORK=mainnet
       - WALLET_PASSWORD=
       - EXTRA_OPTS=
     restart: unless-stopped
 volumes:
-  rocketpool-testnet: {}
+  rocketpool: {}

--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -4,7 +4,7 @@ fields:
     target:
       type: environment
       name: WALLET_PASSWORD
-      service: rocketpool-testnet.public.dappnode.eth
+      service: rocketpool.public.dappnode.eth
     title: Wallet password
     secret: true
     required: true


### PR DESCRIPTION
Only package files changed, not the UI, nor the API
- `rocketpool-testnet.public.dappnode` -> `rocketpool.public.dappnode`
- `EXECUTION_CLIENT_PRATER` -> `EXECUTION_CLIENT_MAINNET`