### PR TITLE
Bump Smartnode to v1.20.3 + fix auto-bump workflow

### DIFF
--- a/.github/workflows/auto_check.yml
+++ b/.github/workflows/auto_check.yml
@@ -5,13 +5,18 @@ on:
     - cron: "00 */4 * * *"
   push:
     branches:
-      - "master"
+      - "main"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: npx @dappnode/dappnodesdk github-action bump-upstream
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build/user-settings_template.yml
+++ b/build/user-settings_template.yml
@@ -138,6 +138,7 @@ lodestar:
   additionalVcFlags: ""
   containerTag: chainsafe/lodestar:v1.33.0
   maxPeers: "100"
+  p2pQuicPort: "8001"
 mevBoost:
   additionalFlags: ""
   aestusEnabled: "false"
@@ -207,6 +208,7 @@ prysm:
   vcContainerTag: gcr.io/offchainlabs/prysm/validator:v6.0.4
 root:
   bnMetricsPort: "9100"
+  enableIPv6: "false"
   consensusClient: nimbus
   consensusClientMode: external
   ecMetricsPort: "9105"
@@ -224,9 +226,10 @@ root:
   rpDir: /app/rocketpool/
   useFallbackClients: "false"
   vcMetricsPort: "9101"
-  version: v1.17.3
+  version: v1.20.3
   watchtowerMetricsPort: "9104"
 smartnode:
+  apiPort: "8280"
   archiveECUrl: ""
   autoInitVPThreshold: "5"
   dataPath: /rocketpool/data

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "rocketpool.dnp.dappnode.eth",
-  "version": "0.1.8",
-  "upstreamVersion": "v1.19.3",
+  "version": "0.1.9",
+  "upstreamVersion": "v1.20.3",
   "upstreamRepo": "rocket-pool/smartnode",
   "architectures": ["linux/amd64"],
   "description": "How Rocket Pool Works. Unlike solo stakers, who are required to put 32 ETH up for deposit to create a new validator, Rocket Pool nodes only need to deposit 8/16 ETH per validator. This will be coupled with 16 ETH from the staking pool (which stakers deposited in exchange for rETH) to create a new Ethereum validator. This new validator is called a minipool.",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: ./build
       args:
-        UPSTREAM_VERSION: v1.19.3
+        UPSTREAM_VERSION: v1.20.3
         NETWORK: mainnet
     volumes:
       - rocketpool:/rocketpool


### PR DESCRIPTION
## What

1. Bumps the bundled Smartnode from **v1.19.3 → v1.20.3** (latest stable upstream, published 2026-05-21). The package was ~3 months behind.
2. Fixes the `auto_check.yml` upstream-bump workflow so future Smartnode releases open PRs automatically.

## Changes

- `docker-compose.yml`: `UPSTREAM_VERSION` v1.19.3 → v1.20.3
- `dappnode_package.json`: `upstreamVersion` v1.19.3 → v1.20.3; package `version` 0.1.8 → 0.1.9
- `.github/workflows/auto_check.yml`:
  - push trigger branch `master` → `main` (repo default is `main`, so it never fired on merges)
  - add `permissions: contents: write / pull-requests: write` (the default read-only `GITHUB_TOKEN` can't create the branch/PR that `dappnodesdk bump-upstream` needs)
  - `actions/checkout@v2` → `@v4`; add `workflow_dispatch` for manual runs

## Notes

- v1.20.3 is the current latest stable Smartnode release — fetched via the existing `build/Dockerfile` `linux-amd64` CLI + daemon assets, so no build changes needed.
- This stable line includes the new Saturn/megapool CLI command groups in the bundled Smartnode binary. This PR does not add Dappnode-specific UI flows for 4-ETH/megapool deposits; it keeps the package update scoped to the stable binary bump, native-mode settings alignment, and auto-bump workflow repair.
- Like the immich package, the scheduled bump workflow may need a one-time re-enable in the repo Actions tab if GitHub has auto-disabled it for inactivity.
